### PR TITLE
Modify card seeding, implement basic decks, verify client can access

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 		"submodule": "git submodule init"
 	},
 	"postStartCommand": {
-		"fetchData": "node server/scripts/fetchdata.js && node server/scripts/importstandalonedecks.js"
+		"fetchData": "node server/scripts/fetchdata.js"
 	},
 	"customizations": {
 		"vscode": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
       {
         "type": "shell",
         "label": "Fetch Card Data",
-        "command": "node server${pathSeparator}scripts${pathSeparator}fetchdata.js && node server${pathSeparator}scripts${pathSeparator}importstandalonedecks.js",
+        "command": "node server${pathSeparator}scripts${pathSeparator}fetchdata.js",
         "problemMatcher": []
       },
       {

--- a/client/Components/Games/NewGame.jsx
+++ b/client/Components/Games/NewGame.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { Formik } from 'formik';
 import { Button, Input, Select, SelectItem } from '@nextui-org/react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -6,7 +6,7 @@ import * as yup from 'yup';
 
 import GameOptions from './GameOptions';
 import GameTypes from './GameTypes';
-import { useGetRestrictedListQuery } from '../../redux/middleware/api';
+//import { useGetRestrictedListQuery } from '../../redux/middleware/api';
 import Panel from '../Site/Panel';
 import { sendNewGameMessage } from '../../redux/reducers/lobby';
 import AlertPanel, { AlertType } from '../Site/AlertPanel';
@@ -21,24 +21,25 @@ const NewGame = ({
     onClosed
 }) => {
     const dispatch = useDispatch();
-    const { data: restrictedLists } = useGetRestrictedListQuery({});
+    //const { data: restrictedLists } = useGetRestrictedListQuery({});
 
     const connected = useSelector((state) => state.lobby.connected);
     const user = useSelector((state) => state.auth.user);
-    const [restrictedList, setRestrictedList] = useState(restrictedLists?.[0]._id);
+    //const [restrictedList, setRestrictedList] = useState(restrictedLists?.[0]._id);
+    const [side, setSide] = useState('Light');
 
-    useEffect(() => {
-        if (!restrictedList && restrictedLists?.length) {
-            setRestrictedList(restrictedLists[0]._id);
-        }
-    }, [restrictedList, restrictedLists]);
+    // useEffect(() => {
+    //     if (!restrictedList && restrictedLists?.length) {
+    //         setRestrictedList(restrictedLists[0]._id);
+    //     }
+    // }, [restrictedList, restrictedLists]);
 
-    const restrictedListsById = useMemo(() => {
-        return restrictedLists?.reduce((acc, rl) => {
-            acc[rl._id] = rl;
-            return acc;
-        }, {});
-    }, [restrictedLists]);
+    // const restrictedListsById = useMemo(() => {
+    //     return restrictedLists?.reduce((acc, rl) => {
+    //         acc[rl._id] = rl;
+    //         return acc;
+    //     }, {});
+    // }, [restrictedLists]);
 
     const schema = yup.object({
         name: yup
@@ -81,9 +82,7 @@ const NewGame = ({
             <Formik
                 validationSchema={schema}
                 onSubmit={(values) => {
-                    const newGame = Object.assign({}, values, {
-                        restrictedList: restrictedListsById[restrictedList]
-                    });
+                    const newGame = Object.assign({}, values, { ownerSide: side });
 
                     dispatch(sendNewGameMessage(newGame));
                 }}
@@ -138,17 +137,12 @@ const NewGame = ({
                                             </div>
                                             <div>
                                                 <Select
-                                                    label={'Mode'}
-                                                    selectedKeys={new Set([restrictedList])}
-                                                    onChange={(e) =>
-                                                        setRestrictedList(e.target.value)
-                                                    }
+                                                    label={'Side'}
+                                                    selectedKeys={[side]}
+                                                    onChange={(e) => setSide(e.target.value)}
                                                 >
-                                                    {restrictedLists?.map((rl) => (
-                                                        <SelectItem key={rl._id} value={rl._id}>
-                                                            {rl.name}
-                                                        </SelectItem>
-                                                    ))}
+                                                    <SelectItem key={'Light'}>Light</SelectItem>
+                                                    <SelectItem key={'Dark'}>Dark</SelectItem>
                                                 </Select>
                                             </div>
                                         </div>

--- a/client/Components/Games/PendingGame.jsx
+++ b/client/Components/Games/PendingGame.jsx
@@ -288,7 +288,7 @@ const PendingGame = () => {
                         setShowModal(false);
                         dispatch(sendSelectDeckMessage(deck._id));
                     }}
-                    restrictedList={currentGame.restrictedList?._id}
+                    side={currentGame.players[user.username].side}
                 />
             )}
         </>

--- a/client/Components/Games/SelectDeckModal.jsx
+++ b/client/Components/Games/SelectDeckModal.jsx
@@ -1,30 +1,28 @@
 import React from 'react';
 import { Modal, ModalBody, ModalContent, ModalHeader } from '@nextui-org/react';
-import DeckList from '../Decks/DeckList';
+import { useGetStarterDecksQuery } from '../../redux/middleware/api';
+import LoadingSpinner from '../Site/LoadingSpinner';
 
-const SelectDeckModal = ({ onClose, onDeckSelected, restrictedList }) => {
+const SelectDeckModal = ({ onClose, onDeckSelected, side }) => {
     //  const standaloneDecks = useSelector((state) => state.cards.standaloneDecks);
+    const { data: decks, isLoading } = useGetStarterDecksQuery(side);
+
     return (
         <>
             <Modal isOpen={true} onClose={onClose} size='5xl'>
                 <ModalContent>
                     <ModalHeader>{'Select Deck'}</ModalHeader>
                     <ModalBody>
-                        <div>
-                            <DeckList
-                                onDeckSelected={onDeckSelected}
-                                readOnly={true}
-                                restrictedList={restrictedList}
-                            />
-                            {/*standaloneDecks && standaloneDecks.length !== 0 && (
+                        {isLoading ? (
+                            <LoadingSpinner label={'Loading decks...'} />
+                        ) : (
                             <div>
-                                <h4 className='deck-list-header'>
-                                    <Trans>Or choose a standalone deck</Trans>:
-                                </h4>
-                                <DeckList standaloneDecks onDeckSelected={onDeckSelected} />
+                                <h4 className='deck-list-header'>Choose a starter deck</h4>
+                                {decks.map((deck) => (
+                                    <div key={deck._id}>{deck.name}</div>
+                                ))}
                             </div>
-                        )*/}
-                        </div>
+                        )}
                     </ModalBody>
                 </ModalContent>
             </Modal>

--- a/client/menus.js
+++ b/client/menus.js
@@ -1,5 +1,5 @@
 export const LeftMenu = [
-    { path: '/decks', title: 'Decks', showOnlyWhenLoggedIn: true },
+    // { path: '/decks', title: 'Decks', showOnlyWhenLoggedIn: true },
     { path: '/play', title: 'Play' },
     {
         title: 'Help',

--- a/client/redux/middleware/api.js
+++ b/client/redux/middleware/api.js
@@ -141,6 +141,17 @@ export const apiSlice = createApi({
                 ...(result.data || [].map(({ _id }) => ({ type: TagTypes.Deck, _id })))
             ]
         }),
+        getStarterDecks: builder.query({
+            query: (side) => {
+                return {
+                    url: `/decks/starter/${side}`
+                };
+            },
+            providesTags: (result = { data: [] }) => [
+                TagTypes.Deck,
+                ...(result.data || [].map(({ _id }) => ({ type: TagTypes.Deck, _id })))
+            ]
+        }),
         getDecks: builder.query({
             query: (loadOptions) => {
                 return {
@@ -471,6 +482,7 @@ export const apiSlice = createApi({
 export const {
     useGetNewsQuery,
     useGetAllNewsQuery,
+    useGetStarterDecksQuery,
     useGetDecksQuery,
     useGetCardsQuery,
     useGetRestrictedListQuery,

--- a/server/api/decks.js
+++ b/server/api/decks.js
@@ -32,13 +32,10 @@ export const init = async function (server, options) {
     );
 
     server.get(
-        '/api/decks',
+        '/api/decks/starter/:side',
         passport.authenticate('jwt', { session: false }),
         wrapAsync(async function (req, res) {
-            let decks = await deckService.findByUserName(
-                req.user.username,
-                qs.parse(req._parsedUrl.query, { allowDots: true })
-            );
+            let decks = await deckService.findByStarterDecks(req.params.side);
             res.send(decks);
         })
     );

--- a/server/lobby.js
+++ b/server/lobby.js
@@ -862,7 +862,8 @@ class Lobby {
             gameTimeLimit: game.gameTimeLimit,
             useChessClocks: game.useChessClocks,
             chessClockTimeLimit: game.chessClockTimeLimit,
-            delayToStartClock: game.delayToStartClock
+            delayToStartClock: game.delayToStartClock,
+            ownerSide: game.ownerSide
         });
         newGame.rematch = true;
 

--- a/server/pendinggame.js
+++ b/server/pendinggame.js
@@ -29,6 +29,7 @@ class PendingGame {
         this.delayToStartClock = details.delayToStartClock;
         this.started = false;
         this.maxPlayers = 2;
+        this.ownerSide = details.ownerSide;
     }
 
     // Getters
@@ -103,8 +104,19 @@ class PendingGame {
             id: id,
             name: user.username,
             user: user,
-            owner: this.owner.username === user.username
+            owner: this.owner.username === user.username,
+            side: this.getSideByUser(user)
         };
+    }
+
+    getSideByUser(user) {
+        if (this.owner.username === user.username) {
+            return this.ownerSide;
+        } else {
+            // This user is not the owner, so return the opposite side
+            // of the owner
+            return this.ownerSide === 'Light' ? 'Dark' : 'Light';
+        }
     }
 
     addSpectator(id, user) {
@@ -362,7 +374,8 @@ class PendingGame {
                 name: player.name,
                 owner: player.owner,
                 role: player.user.role,
-                settings: player.user.settings
+                settings: player.user.settings,
+                side: player.side
             };
         });
 
@@ -395,7 +408,8 @@ class PendingGame {
             muteSpectators: this.muteSpectators,
             useChessClocks: this.useChessClocks,
             chessClockTimeLimit: this.chessClockTimeLimit,
-            delayToStartClock: this.delayToStartClock
+            delayToStartClock: this.delayToStartClock,
+            ownerSide: this.ownerSide
         };
     }
 

--- a/server/scripts/buildStarterDecks.js
+++ b/server/scripts/buildStarterDecks.js
@@ -1,0 +1,101 @@
+/*eslint no-console:0 */
+
+import monk from 'monk';
+import ServiceFactory from '../services/ServiceFactory.js';
+import CardService from '../services/CardService.js';
+import DeckService from '../services/DeckService.js';
+
+class BuildStarterDecks {
+    constructor() {
+        let configService = ServiceFactory.configService();
+        this.db = monk(configService.getValue('dbPath'));
+        this.cardService = new CardService(this.db);
+        this.deckService = new DeckService(this.db, this.cardService);
+    }
+
+    async build() {
+        try {
+            await this.deckService.init();
+            this.cards = await this.cardService.getAllCards();
+
+            const sithStarterDeck = this.formatDeck(
+                this.buildDeck({
+                    name: 'Sith Starter Deck',
+                    username: 'STARTERDECKS',
+                    affiliation: 'Sith',
+                    side: 'Dark',
+                    blockNumbers: [19, 20, 21, 22, 23, 24, 25, 36]
+                })
+            );
+
+            const jediStarterDeck = this.formatDeck(
+                this.buildDeck({
+                    name: 'Jedi Starter Deck',
+                    username: 'STARTERDECKS',
+                    affiliation: 'Jedi',
+                    side: 'Light',
+                    blockNumbers: [1, 2, 3, 4, 5, 6, 7, 18]
+                })
+            );
+
+            await this.deckService.create(sithStarterDeck);
+            await this.deckService.create(jediStarterDeck);
+        } catch (err) {
+            console.error('Could not finish import', err);
+        } finally {
+            this.db.close();
+        }
+    }
+
+    formatDeck(deck) {
+        let drawCards = deck.cards.filter((card) =>
+            ['Enhancement', 'Event', 'Fate', 'Mission', 'Unit'].includes(this.cards[card.code].type)
+        );
+        let objectiveCards = deck.cards.filter(
+            (card) => this.cards[card.code].type === 'Objective'
+        );
+        let formattedDeck = {
+            name: deck.name,
+            side: deck.side,
+            username: deck.username,
+
+            // Not sure if aggregating counts is important yet
+            drawCards: drawCards.map((card) => ({ count: 1, card: card })),
+            objectiveCards: objectiveCards.map((card) => ({
+                count: 1,
+                card: card
+            })),
+            lastUpdated: Date.now(),
+            affiliation: deck.affiliation
+        };
+
+        return formattedDeck;
+    }
+
+    buildDeck({ name, username, affiliation, side, blockNumbers }) {
+        let deck = {
+            name,
+            username,
+            side,
+            cards: []
+        };
+
+        deck.affiliation = Object.values(this.cards).find(
+            (card) => card.type === 'Affiliation' && card.affiliationName === affiliation
+        );
+
+        for (let blockNumber of blockNumbers) {
+            let cardsInBlock = Object.values(this.cards).filter(
+                (card) => card.block === blockNumber
+            );
+            deck.cards = deck.cards.concat(cardsInBlock);
+        }
+
+        return deck;
+    }
+}
+
+let builder = new BuildStarterDecks();
+await builder.build();
+
+process.exit(0);

--- a/server/scripts/fetchdata.js
+++ b/server/scripts/fetchdata.js
@@ -16,7 +16,7 @@ const optionsDefinition = [
     {
         name: 'card-dir',
         type: String,
-        defaultValue: path.join(__dirname, '..', '..', 'throneteki-json-data')
+        defaultValue: path.join(__dirname, '..', '..', 'swlcgdb-json-data')
     },
     { name: 'image-source', type: String, defaultValue: 'cardgamedb' },
     {
@@ -24,7 +24,7 @@ const optionsDefinition = [
         type: String,
         defaultValue: path.join(__dirname, '..', '..', 'public', 'img', 'cards')
     },
-    { name: 'no-images', type: Boolean, defaultValue: false }
+    { name: 'no-images', type: Boolean, defaultValue: true }
 ];
 
 function createDataSource(options) {
@@ -59,4 +59,6 @@ let dataSource = createDataSource(options);
 let imageSource = createImageSource(options);
 let cardImport = new CardImport(db, dataSource, imageSource, options['image-dir']);
 
-cardImport.import();
+await cardImport.import();
+
+process.exit(0);

--- a/server/scripts/fetchdata/JsonCardSource.js
+++ b/server/scripts/fetchdata/JsonCardSource.js
@@ -39,16 +39,23 @@ class JsonCardSource {
     }
 
     addLabelToCards(cards) {
-        for (let card of cards) {
-            let cardsByName = _.filter(cards, (filterCard) => {
-                return filterCard.name === card.name;
-            });
+        // Don't need to worry about this yet
 
-            if (cardsByName.length > 1) {
-                card.label = card.name + ' (' + card.packCode + ')';
-            } else {
-                card.label = card.name;
-            }
+        // for (let card of cards) {
+        //     let cardsByName = _.filter(cards, (filterCard) => {
+        //         return filterCard.name === card.name;
+        //     });
+
+        //     if (cardsByName.length > 1) {
+        //         card.label = card.name + ' (' + card.packCode + ')';
+        //     } else {
+        //         card.label = card.name;
+        //     }
+        // }
+
+        // Just going to set it to the name for now
+        for (let card of cards) {
+            card.label = card.name;
         }
     }
 

--- a/server/services/DeckService.js
+++ b/server/services/DeckService.js
@@ -10,7 +10,7 @@ class DeckService {
 
     async init() {
         this.packs = await this.cardService.getAllPacks();
-        this.restrictedLists = await this.cardService.getRestrictedList();
+        //this.restrictedLists = await this.cardService.getRestrictedList();
         this.cards = await this.cardService.getAllCards();
     }
 
@@ -25,12 +25,12 @@ class DeckService {
 
         formattedDeck.status = {};
 
-        for (const restrictedList of this.restrictedLists) {
-            formattedDeck.status[restrictedList._id] = validateDeck(formattedDeck, {
-                packs: this.packs,
-                restrictedLists: [restrictedList]
-            });
-        }
+        // for (const restrictedList of this.restrictedLists) {
+        //     formattedDeck.status[restrictedList._id] = validateDeck(formattedDeck, {
+        //         packs: this.packs,
+        //         restrictedLists: [restrictedList]
+        //     });
+        // }
 
         return formattedDeck;
     };
@@ -71,6 +71,12 @@ class DeckService {
             logger.error('Unable to fetch standalone deck %s', err);
             throw new Error('Unable to fetch standalone deck ' + id);
         });
+    }
+
+    async findByStarterDecks(side) {
+        const dbDecks = await this.decks.find({ username: 'STARTERDECKS', side: side });
+
+        return dbDecks.map(this.processDeck);
     }
 
     async findByUserName(username, options = {}) {
@@ -164,24 +170,23 @@ class DeckService {
 
     async create(deck) {
         //if the eventId is set on a new deck, check if the user already has a deck with the same eventId
-        if (deck.eventId) {
-            //if a deck for the event already exists, do not create the new deck
-            if (await this.userAlreadyHasDeckForEvent(deck.username, deck.eventId)) {
-                throw new Error(
-                    `User ${deck.username} already has a deck configured for event ${deck.eventId}`
-                );
-            }
-        }
+        // if (deck.eventId) {
+        //     //if a deck for the event already exists, do not create the new deck
+        //     if (await this.userAlreadyHasDeckForEvent(deck.username, deck.eventId)) {
+        //         throw new Error(
+        //             `User ${deck.username} already has a deck configured for event ${deck.eventId}`
+        //         );
+        //     }
+        // }
 
         let properties = {
             username: deck.username,
             name: deck.name,
-            plotCards: deck.plotCards,
-            bannerCards: deck.bannerCards,
+            objectiveCards: deck.objectiveCards,
             drawCards: deck.drawCards,
-            eventId: deck.eventId,
-            faction: deck.faction,
-            agenda: deck.agenda,
+            //eventId: deck.eventId,
+            affiliation: deck.affiliation,
+            side: deck.side,
             lastUpdated: new Date()
         };
 


### PR DESCRIPTION
Still hacking away at basic stuff.  Here's what's included here:

- Point deck selection at the starter decks from SWLCGDB
- Create scripts to read from swlcgdb data (not committed here, but saved locally) to a JSON format for inserting into Mongo
- Edit the devContainer settings and task settings in vs code, so it doesn't keep dumping in the thrones data
- Insert data for the starting decks and make sure they show up in the relevant data payloads that get passed around in the various websocket messages
- Hide deck builder and import functionality (for now)

